### PR TITLE
Disable TESTING option for kagome

### DIFF
--- a/cmake/projects/kagome/hunter.cmake
+++ b/cmake/projects/kagome/hunter.cmake
@@ -9,6 +9,7 @@ include(hunter_add_version)
 include(hunter_cacheable)
 include(hunter_download)
 include(hunter_pick_scheme)
+include(hunter_cmake_args)
 
 hunter_add_version(
     PACKAGE_NAME
@@ -19,6 +20,12 @@ hunter_add_version(
     "https://github.com/soramitsu/kagome/archive/v0.0.1.tar.gz"
     SHA1
     b3690c673b48c413b521adec9eeae95ebf283c83
+)
+
+hunter_cmake_args(
+    kagome
+    CMAKE_ARGS
+        TESTING=OFF
 )
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)


### PR DESCRIPTION
TESTING option is added to kagome in [this PR](https://github.com/soramitsu/kagome/pull/474) that enables removing tests from a build.
It should be disabled for Hunter installation.

<!--- Use this part of template if you're updating existing package. Remove the rest. -->
<!--- BEGIN -->

* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully.

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/<username>/hunter/build/<build-number>
  * https://travis-ci.org/<username>/hunter/builds/<build-number>

---
<!--- END -->

