### PR TITLE
Updated wavm version

### DIFF
--- a/cmake/projects/wavm/hunter.cmake
+++ b/cmake/projects/wavm/hunter.cmake
@@ -39,7 +39,7 @@ hunter_add_version(
     URL
     "https://github.com/soramitsu/WAVM/archive/refs/heads/uninit-diag.zip"
     SHA1
-    fa7b5dbfbd63a31ccfd90b54c48e624ee64492f9
+    3a9edca3e6a76e51d39ec728b9a26039d8a4d8d7
 )
 
 hunter_cmake_args(

--- a/cmake/projects/wavm/hunter.cmake
+++ b/cmake/projects/wavm/hunter.cmake
@@ -37,9 +37,9 @@ hunter_add_version(
     VERSION
     1.0.4-r
     URL
-    "https://github.com/soramitsu/WAVM/archive/refs/heads/uninit-diag.zip"
+    "https://github.com/soramitsu/WAVM/archive/refs/tags/1.0.4-r.zip"
     SHA1
-    3a9edca3e6a76e51d39ec728b9a26039d8a4d8d7
+    bcb4be1401d0fdc6ab41a0417b470f001cc1b6f5
 )
 
 hunter_cmake_args(

--- a/cmake/projects/wavm/hunter.cmake
+++ b/cmake/projects/wavm/hunter.cmake
@@ -31,6 +31,17 @@ hunter_add_version(
     919aafc29dae892bf4eacd724e7058ad00ca8b8e
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    wavm
+    VERSION
+    1.0.4-r
+    URL
+    "https://github.com/soramitsu/WAVM/archive/refs/heads/uninit-diag.zip"
+    SHA1
+    fa7b5dbfbd63a31ccfd90b54c48e624ee64492f9
+)
+
 hunter_cmake_args(
     wavm
     CMAKE_ARGS


### PR DESCRIPTION
Updated WAVM version to fix build in kagome (-Werror=uninitialized on gcc-12)
Related issue: soramitsu/kagome#1246