### PR TITLE
Update soralog to v0.1.5

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -482,7 +482,7 @@ hunter_default_version(shaka_player_embedded VERSION 0.1.0-beta-p1)
 hunter_default_version(sleef VERSION 3.3.1-p1)
 hunter_default_version(sm VERSION 1.2.3)
 hunter_default_version(soil VERSION 1.0.4)
-hunter_default_version(soralog VERSION 0.1.4)
+hunter_default_version(soralog VERSION 0.1.5)
 hunter_default_version(sources_for_android_sdk_packer VERSION 1.0.0)
 hunter_default_version(sparsehash VERSION 2.0.2)
 

--- a/cmake/projects/soralog/hunter.cmake
+++ b/cmake/projects/soralog/hunter.cmake
@@ -15,13 +15,6 @@ hunter_add_version(
 
 hunter_add_version(
     PACKAGE_NAME soralog
-    VERSION "0.1.2"
-    URL "https://github.com/soramitsu/soralog/archive/v0.1.2.tar.gz"
-    SHA1 "f3de7b8ef5069b29104216919dfcaa790c0f5e13"
-)
-
-hunter_add_version(
-    PACKAGE_NAME soralog
     VERSION "0.1.3"
     URL "https://github.com/soramitsu/soralog/archive/v0.1.3.tar.gz"
     SHA1 "4a550cd7c21dd51a62171d83818188db14d4691b"
@@ -29,9 +22,9 @@ hunter_add_version(
 
 hunter_add_version(
     PACKAGE_NAME soralog
-    VERSION "0.1.4"
-    URL "https://github.com/soramitsu/soralog/archive/v0.1.4.tar.gz"
-    SHA1 "50ecfac2cc0a6c975737a62a37120986a7d8df22"
+    VERSION "0.1.5"
+    URL  https://github.com/soramitsu/soralog/archive/refs/tags/v0.1.5.tar.gz
+    SHA1 88664218fc6430ed8d782aaeec665b43ec10c702
 )
 
 hunter_cmake_args(


### PR DESCRIPTION
<!--- Use this part of template if you're updating existing package. Remove the rest. -->
<!--- BEGIN -->

* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **Yes**

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/<username>/hunter/build/<build-number>
  * https://travis-ci.org/<username>/hunter/builds/<build-number>

<!--- Remove next line if this update doesn't break old toolchains -->
* This update will break few old toolchains.
  They are excluded in this pull request: https://github.com/cpp-pm/hunter-testing/pull/<number>

---
<!--- END -->
