### PR TITLE
update llvm v12.0.1-p2

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -84,7 +84,7 @@ hunter_default_version(Immer VERSION 0.6.2-cf44615)
 hunter_default_version(Jpeg VERSION 9c-p0)
 hunter_default_version(JsonSpirit VERSION 0.0.4-hunter)
 hunter_default_version(LAPACK VERSION 3.7.1)
-hunter_default_version(LLVM VERSION 12.0.1-p1) # Clang
+hunter_default_version(LLVM VERSION 12.0.1-p2) # Clang
 hunter_default_version(LLVMCompilerRT VERSION 12.0.1) # Clang
 hunter_default_version(Lager VERSION 0.0.0-dbc1fde-p0)
 hunter_default_version(Leathers VERSION 0.1.8)

--- a/cmake/projects/LLVM/hunter.cmake
+++ b/cmake/projects/LLVM/hunter.cmake
@@ -15,6 +15,17 @@ hunter_add_version(
     PACKAGE_NAME
     LLVM
     VERSION
+    "12.0.1-p2"
+    URL
+    "https://github.com/soramitsu/kagome-llvm/archive/v12.0.1-p2.tar.gz"
+    SHA1
+    10239d9e12bc924e01237655b4cd84c50e0d8a64
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    LLVM
+    VERSION
     "12.0.1-p1"
     URL
     "https://github.com/soramitsu/kagome-llvm/archive/v12.0.1-p1.tar.gz"


### PR DESCRIPTION
- update llvm v12.0.1-p2
  - [Don't processFDE for AArch64](https://github.com/soramitsu/kagome-llvm/commit/600e714e75b6e9601c479877f0e41dedd35e6fea) (fix try-catch not catching on MacOS M1)